### PR TITLE
Add the option to shorten the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ cucumber {
     help = ''
     i18n = ''
     wip = ''
+    shorten = ''
 
     featurePath = 'src/test/resources'
     main = 'cucumber.api.cli.Main'

--- a/README.md
+++ b/README.md
@@ -141,6 +141,28 @@ cucumber {
 
 This will use as many threads as possible while leaving resources for Gradle to execute.
 
+### Shortening the command line
+
+To solve the issue on Windows where there is a command line's length limit, use the option `--shorten`. The plugin will shorten the command line by making a temporary file for the classpath
+
+you can specify them in the build file like this:
+
+```groovy
+cucumber {
+    shorten = manifest
+}
+```
+
+or via the command line:
+
+```shell
+--shorten manifest
+```
+
+there are two possible values:
+- `manifest`, using a temporary manifest jar file to supply the classpath
+- `argfile`, using @argFile to supply the classpath (Java 9+) 
+
 ### --junit
 
 Cucumber support setting properties for `junit` from the command line. The option `--junit` is not supported. 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
     mavenLocal()
 }
 
-version = "0.0.9"
+version = "0.0.10"
 group = "se.thinkcode"
 
 dependencies {

--- a/src/main/java/se/thinkcode/ClasspathShortener.java
+++ b/src/main/java/se/thinkcode/ClasspathShortener.java
@@ -1,0 +1,21 @@
+package se.thinkcode;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+
+public class ClasspathShortener {
+    public static String createJava9argFile(String classpath, String tempDir) {
+        String argFile = Paths.get(tempDir,"cucumber_runner_argFile").toString();
+        try {
+            PrintWriter writer = new PrintWriter(argFile, StandardCharsets.UTF_8);
+            writer.println("-classpath\n" + classpath);
+            writer.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new RuntimeException(String.format("Cannot write temporary file on %s,\nexception message:\n %s", argFile, e.getMessage()));
+        }
+        return argFile;
+    }
+}

--- a/src/main/java/se/thinkcode/ClasspathShortener.java
+++ b/src/main/java/se/thinkcode/ClasspathShortener.java
@@ -1,21 +1,69 @@
 package se.thinkcode;
 
-import java.io.IOException;
-import java.io.PrintWriter;
+import java.io.*;
+import java.net.MalformedURLException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.jar.*;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
 
 public class ClasspathShortener {
     public static String createJava9argFile(String classpath, String tempDir) {
-        String argFile = Paths.get(tempDir,"cucumber_runner_argFile").toString();
+        String argFile = Paths.get(tempDir, "cucumber_runner_argFile").toString();
         try {
-            PrintWriter writer = new PrintWriter(argFile, StandardCharsets.UTF_8);
+            OutputStream file = new FileOutputStream(argFile);
+            PrintWriter writer = new PrintWriter(new OutputStreamWriter(file, StandardCharsets.UTF_8));
             writer.println("-classpath\n" + classpath);
             writer.close();
         } catch (IOException e) {
             e.printStackTrace();
-            throw new RuntimeException(String.format("Cannot write temporary file on %s,\nexception message:\n %s", argFile, e.getMessage()));
+            throw new RuntimeException(
+                    String.format("Cannot write temporary file on %s,\nexception message:\n %s",
+                            argFile, e.getMessage()
+                    ));
         }
         return argFile;
+    }
+
+    public static String createManifestJarFile(String classpath, String tempDir) {
+        String manifestJarFile = Paths.get(tempDir, "cucumber_runner_manifest.jar").toString();
+        Manifest manifest = createManifestWithClasspath(classpath);
+        JarOutputStream jarOutputStream;
+        try {
+            jarOutputStream = new JarOutputStream(new FileOutputStream(manifestJarFile), manifest);
+            jarOutputStream.putNextEntry(new ZipEntry("META-INF/"));
+            jarOutputStream.close();
+            return manifestJarFile;
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new RuntimeException(
+                    String.format("Cannot write temporary file on %s,\nexception message:\n %s",
+                            manifestJarFile, e.getMessage()
+                    ));
+        }
+    }
+
+    private static Manifest createManifestWithClasspath(String classpath) {
+        Manifest manifest = new Manifest();
+        Attributes attributes = manifest.getMainAttributes();
+        attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        if (classpath != null) {
+            String classpathAttr = Arrays.stream(classpath.split(";")).map(
+                    ClasspathShortener::getURL
+            ).collect(Collectors.joining(" "));
+            attributes.putValue("Class-Path", classpathAttr);
+        }
+        return manifest;
+    }
+
+    private static String getURL(String path) {
+        try {
+            return Paths.get(path).toUri().toURL().toString();
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/main/java/se/thinkcode/CommandLineBuilder.java
+++ b/src/main/java/se/thinkcode/CommandLineBuilder.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Properties;
 
 import static se.thinkcode.ClasspathShortener.createJava9argFile;
+import static se.thinkcode.ClasspathShortener.createManifestJarFile;
 
 class CommandLineBuilder {
 
@@ -51,19 +52,27 @@ class CommandLineBuilder {
     }
 
     private void addClasspath(List<String> command, String classpath, CucumberExtension extension, CucumberTask commandLineOption) {
-        boolean doShorten;
-        if (commandLineOption.shorten) {
-            doShorten = true;
-        } else {
-            doShorten = !extension.shorten.isEmpty();
+        String shorten = "none";
+        if (commandLineOption.shorten != null) {
+            shorten = commandLineOption.shorten;
+        } else if (!extension.shorten.isEmpty()) {
+            shorten = extension.shorten;
         }
-        if (doShorten) {
-            String tempDir = commandLineOption.getTemporaryDir().getAbsolutePath();
-            String argFile = createJava9argFile(classpath, tempDir);
-            command.add("@" + argFile);
-        } else {
-            command.add("-cp");
-            command.add(classpath);
+        String tempDir;
+        switch (shorten) {
+            case "manifest":
+                tempDir = commandLineOption.getTemporaryDir().getAbsolutePath();
+                command.add("-cp");
+                command.add(createManifestJarFile(classpath, tempDir));
+                break;
+            case "argfile":
+                tempDir = commandLineOption.getTemporaryDir().getAbsolutePath();
+                command.add("@" + createJava9argFile(classpath, tempDir));
+                break;
+            default:
+                command.add("-cp");
+                command.add(classpath);
+                break;
         }
     }
 

--- a/src/main/java/se/thinkcode/CommandLineBuilder.java
+++ b/src/main/java/se/thinkcode/CommandLineBuilder.java
@@ -1,11 +1,11 @@
 package se.thinkcode;
 
 import java.io.*;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
+
+import static se.thinkcode.ClasspathShortener.createJava9argFile;
 
 class CommandLineBuilder {
 
@@ -58,16 +58,9 @@ class CommandLineBuilder {
             doShorten = !extension.shorten.isEmpty();
         }
         if (doShorten) {
-            String argFile = Paths.get(commandLineOption.getTemporaryDir().getAbsolutePath(),"cucumber_runner_argFile").toString();
-            try {
-                PrintWriter writer = new PrintWriter(argFile, StandardCharsets.UTF_8);
-                writer.println("-classpath\n" + classpath);
-                writer.close();
-                command.add("@" + argFile);
-            } catch (IOException e) {
-                e.printStackTrace();
-                throw new RuntimeException(String.format("Cannot write temporary file on %s,\nexception message:\n %s", argFile, e.getMessage()));
-            }
+            String tempDir = commandLineOption.getTemporaryDir().getAbsolutePath();
+            String argFile = createJava9argFile(classpath, tempDir);
+            command.add("@" + argFile);
         } else {
             command.add("-cp");
             command.add(classpath);

--- a/src/main/java/se/thinkcode/CommandLineBuilder.java
+++ b/src/main/java/se/thinkcode/CommandLineBuilder.java
@@ -241,9 +241,7 @@ class CommandLineBuilder {
         }
     }
 
-    private void addFeaturePath(
-            List<String> command, CucumberExtension extension, CucumberTask commandLineOption, File projectDir
-    ) {
+    private void addFeaturePath(List<String> command, CucumberExtension extension, CucumberTask commandLineOption, File projectDir) {
         String featurePath = commandLineOption.featurePath;
         if (featurePath != null) {
             boolean absolutePath = new File(featurePath).isAbsolute();

--- a/src/main/java/se/thinkcode/CucumberExtension.java
+++ b/src/main/java/se/thinkcode/CucumberExtension.java
@@ -16,6 +16,7 @@ public class CucumberExtension {
     public String help = "";
     public String i18n = "";
     public String wip = "";
+    public String shorten = "";
 
     public String featurePath = "src/test/resources";
 

--- a/src/main/java/se/thinkcode/CucumberTask.java
+++ b/src/main/java/se/thinkcode/CucumberTask.java
@@ -10,10 +10,6 @@ import org.gradle.api.tasks.options.Option;
 import se.thinkcode.stream.StreamConsumer;
 
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.PrintWriter;
-import java.io.UnsupportedEncodingException;
-import java.nio.file.Paths;
 
 public class CucumberTask extends DefaultTask {
 
@@ -122,10 +118,10 @@ public class CucumberTask extends DefaultTask {
     }
 
     @Option(option = "shorten",
-            description = "Shorten the command line using @argFile (Java 9+)")
-    boolean shorten;
+            description = "Shorten the command line by shortening the classpath. Defaults to none. Possible values are [manifest, argfile]")
+    String shorten;
 
-    public void setShorten(boolean shorten) {
+    public void setShorten(String shorten) {
         this.shorten = shorten;
     }
 

--- a/src/main/java/se/thinkcode/CucumberTask.java
+++ b/src/main/java/se/thinkcode/CucumberTask.java
@@ -10,6 +10,10 @@ import org.gradle.api.tasks.options.Option;
 import se.thinkcode.stream.StreamConsumer;
 
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
+import java.nio.file.Paths;
 
 public class CucumberTask extends DefaultTask {
 
@@ -115,6 +119,14 @@ public class CucumberTask extends DefaultTask {
 
     public void setWip(String wip) {
         this.wip = wip;
+    }
+
+    @Option(option = "shorten",
+            description = "Shorten the command line using @argFile (Java 9+)")
+    boolean shorten;
+
+    public void setShorten(boolean shorten) {
+        this.shorten = shorten;
     }
 
     @Option(option = "featurePath",

--- a/src/test/java/se/thinkcode/ClasspathShortenerTest.java
+++ b/src/test/java/se/thinkcode/ClasspathShortenerTest.java
@@ -1,0 +1,27 @@
+package se.thinkcode;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.contentOf;
+
+public class ClasspathShortenerTest {
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void create_argfile() throws IOException {
+        String tempDir = temporaryFolder.newFolder().getAbsolutePath();
+        String expectedClasspath = "faked classpath";
+
+        String argFilePath = ClasspathShortener.createJava9argFile(expectedClasspath, tempDir);
+        File argFile = new File(argFilePath);
+        assertThat(argFile).exists().canRead();
+        assertThat(contentOf(argFile)).startsWith("-classpath").contains(expectedClasspath);
+    }
+}

--- a/src/test/java/se/thinkcode/ClasspathShortenerTest.java
+++ b/src/test/java/se/thinkcode/ClasspathShortenerTest.java
@@ -6,6 +6,8 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.jar.JarFile;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.contentOf;
@@ -28,10 +30,16 @@ public class ClasspathShortenerTest {
     @Test
     public void create_manifest_jar() throws IOException {
         String tempDir = temporaryFolder.newFolder().getAbsolutePath();
-        String expectedClasspath = "faked classpath";
+        String classpath = "faked classpath";
+        String expectedClasspathInJarFile = Paths.get(classpath).toUri().toURL().toString();
 
-        String manifestJarFilePath = ClasspathShortener.createManifestJarFile(expectedClasspath, tempDir);
+        String manifestJarFilePath = ClasspathShortener.createManifestJarFile(classpath, tempDir);
         File manifestJarFile = new File(manifestJarFilePath);
         assertThat(manifestJarFile).exists().canRead();
+        JarFile jarFile = new JarFile(manifestJarFile);
+
+        assertThat(jarFile.getManifest().getMainAttributes().getValue("Class-Path"))
+                .isNotNull()
+                .isEqualTo(expectedClasspathInJarFile);
     }
 }

--- a/src/test/java/se/thinkcode/ClasspathShortenerTest.java
+++ b/src/test/java/se/thinkcode/ClasspathShortenerTest.java
@@ -24,4 +24,14 @@ public class ClasspathShortenerTest {
         assertThat(argFile).exists().canRead();
         assertThat(contentOf(argFile)).startsWith("-classpath").contains(expectedClasspath);
     }
+
+    @Test
+    public void create_manifest_jar() throws IOException {
+        String tempDir = temporaryFolder.newFolder().getAbsolutePath();
+        String expectedClasspath = "faked classpath";
+
+        String manifestJarFilePath = ClasspathShortener.createManifestJarFile(expectedClasspath, tempDir);
+        File manifestJarFile = new File(manifestJarFilePath);
+        assertThat(manifestJarFile).exists().canRead();
+    }
 }


### PR DESCRIPTION
This add the option `--shorten` to solve #3 

there are two shortening method implemented, following IntelliJ ways of doing this

- by using temporary manifest jar file that holds the classpath values. This solution also copies the way https://github.com/viswaramamoorthy/gradle-util-plugins/ solve the issue of length limit in task `JavaExec`

- by using `@argFile`, a temporary text file that contains the classpath arguments, a Java 9+ solution

I can only test this on Windows at the moment and one project of mine who had the length limit issue and everything works fine so far.
