### PR TITLE
Add the option to provide multiple glues

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add the plugin to your project
 
 ```
 plugins {
-  id "se.thinkcode.cucumber-runner" version "0.0.8"
+  id "se.thinkcode.cucumber-runner" version "0.0.11"
 }
 ```
 
@@ -39,6 +39,7 @@ The complete list of options that can be set are these:
 cucumber {
     threads = '4'
     glue = 'classpath:se.thinkcode'
+    extraGlues = ['another.classpath', 'to.include']
     plugin = ['pretty']
     tags = ''
     name = ''
@@ -97,6 +98,31 @@ you can't stack tags. The solution is to put them into quotes like this:
 
 Doing so will forward the expression `not @wip` to the option `-tags` 
 and finally to Cucumber.
+
+#### Glues
+
+Cucumber uses glue to locate where the step definitions are.
+
+Specify them in the build file using `glue` as a string if you use one path and `extraGlues` as an array of strings if
+you need more than one path
+
+```groovy
+glue = 'classpath:se.thinkcode'
+extraGlues = ['another.classpath', 'to.include']
+```
+
+Or specify them as a command line option:
+
+```shell
+--glue "classpath:se.thinkcode"
+```
+
+OR
+
+```shell
+--glue "classpath:se.thinkcode, another.classpath, to.include"
+# The string will be divided into an array with `,` as delimiter. Any whitespace around `,` will be removed. 
+```
 
 #### Plugins
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
     mavenLocal()
 }
 
-version = "0.0.10"
+version = "0.0.11"
 group = "se.thinkcode"
 
 dependencies {

--- a/src/main/java/se/thinkcode/CommandLineBuilder.java
+++ b/src/main/java/se/thinkcode/CommandLineBuilder.java
@@ -126,14 +126,23 @@ class CommandLineBuilder {
 
     private void addGlue(List<String> command, CucumberExtension extension, CucumberTask commandLineOption) {
         if (commandLineOption.glue != null) {
-            command.add("--glue");
-            command.add(commandLineOption.glue);
+            String[] glues = PluginParser.parse(commandLineOption.glue);
+            for (String glue : glues) {
+                command.add("--glue");
+                command.add(glue);
+            }
             return;
         }
 
         if (!extension.glue.isEmpty()) {
             command.add("--glue");
             command.add(extension.glue);
+        }
+        if (extension.extraGlues.length > 0) {
+            for (String glue : extension.extraGlues) {
+                command.add("--glue");
+                command.add(glue);
+            }
         }
     }
 

--- a/src/main/java/se/thinkcode/CucumberExtension.java
+++ b/src/main/java/se/thinkcode/CucumberExtension.java
@@ -5,6 +5,7 @@ public class CucumberExtension {
 
     public String threads = "";
     public String glue = "";
+    public String[] extraGlues = new String[0];
     public String[] plugin = new String[0];
     public String tags = "";
     public String name = "";

--- a/src/test/java/se/thinkcode/CommandLineBuilderTest.java
+++ b/src/test/java/se/thinkcode/CommandLineBuilderTest.java
@@ -132,6 +132,18 @@ public class CommandLineBuilderTest {
     }
 
     @Test
+    public void should_build_command_adding_multiple_glues() {
+        extension.glue = "classpath:se.thinkcode";
+        extension.extraGlues = new String[]{"another.path", "test.path"};
+
+        String[] actual = builder.buildCommand(extension, "faked classpath", commandlineOption, projectDir);
+
+        assertCommandStart(actual);
+        assertThat(actual)
+                .containsSequence("--glue", "classpath:se.thinkcode", "--glue", "another.path", "--glue", "test.path");
+    }
+
+    @Test
     public void should_build_command_adding_glue_from_commandline_option() {
         commandlineOption.glue = "classpath:se.thinkcode";
 
@@ -139,6 +151,17 @@ public class CommandLineBuilderTest {
 
         assertCommandStart(actual);
         assertThat(actual).containsSequence("--glue", "classpath:se.thinkcode");
+    }
+
+    @Test
+    public void should_build_command_adding_multiple_glues_from_commandline_option() {
+        commandlineOption.glue = "classpath:se.thinkcode,another.path,   test.path";
+
+        String[] actual = builder.buildCommand(extension, "faked classpath", commandlineOption, projectDir);
+
+        assertCommandStart(actual);
+        assertThat(actual)
+                .containsSequence("--glue", "classpath:se.thinkcode", "--glue", "another.path", "--glue", "test.path");
     }
 
     @Test


### PR DESCRIPTION
This is an attempt to solve #6

this add the cucumber build command `extraGlues` that accept arrays of string of glues. I use a new option because I haven't found a way to change the current `glue` option that can accept both array and string at the same time without breaking existing functionality.

this also add the option to specify multiple glues via command line option following how multiple plugins are specified

I detailed how to use them in the `README.md`